### PR TITLE
Add NeqSim-backed plant model and wire into Streamlit app

### DIFF
--- a/Streamlit/btx-ots/app.py
+++ b/Streamlit/btx-ots/app.py
@@ -1,14 +1,14 @@
 import streamlit as st
 import numpy as np
 from typing import Dict
-from plant_stub import Plant
+from plant_neqsim import PlantNeqSim
 from ui.image_panel import render_process_panel
 
 st.set_page_config("BTX Benzene Column — Turn-based OTS", layout="wide")
 
 # ---- Session bootstrap ----
 if "plant" not in st.session_state:
-    st.session_state.plant = Plant()
+    st.session_state.plant = PlantNeqSim()
 if "turn" not in st.session_state:
     st.session_state.turn = 0
 if "log" not in st.session_state:
@@ -16,7 +16,7 @@ if "log" not in st.session_state:
 if "phase" not in st.session_state:
     st.session_state.phase = "READY"   # READY -> APPLIED
 
-plant: Plant = st.session_state.plant
+plant: PlantNeqSim = st.session_state.plant
 
 # ---- Safety thresholds (guardrails) ----
 LIMITS = {
@@ -34,7 +34,7 @@ with st.sidebar:
     F_feed       = st.slider("Feed rate (t/h)", 50, 120, 80, step=1)
     controller_choice = st.selectbox("Controller", ["NN policy", "Linear MPC (2×2)"])
     if st.button("Reset scenario"):
-        st.session_state.plant = Plant()
+        st.session_state.plant = PlantNeqSim()
         st.session_state.turn = 0
         st.session_state.log = []
         st.session_state.phase = "READY"

--- a/Streamlit/btx-ots/plant_neqsim.py
+++ b/Streamlit/btx-ots/plant_neqsim.py
@@ -1,0 +1,264 @@
+"""Plant model powered by NeqSim thermo helpers.
+
+This module contains :class:`PlantNeqSim`, a light-weight dynamic
+representation of the benzene/toluene column used by the BTX OTS
+prototype.  The model keeps the same public API as the legacy
+:mod:`plant_stub` module while replacing the heuristic correlations with
+helpers backed by `neqsim` to compute vapour-liquid equilibrium (VLE)
+relationships.  The dynamics are intentionally simple (first order) to
+remain inexpensive for Streamlit, yet the inclusion of the thermo helper
+functions gives the controller and guard-rail logic a more realistic
+response surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency for richer physics
+    from neqsim.thermo import fluid
+    from neqsim.thermo.thermoTools import PHflash, TPflash
+
+    _HAVE_NEQSIM = True
+except Exception:  # pragma: no cover - best effort guardrail
+    fluid = None  # type: ignore[assignment]
+    PHflash = None  # type: ignore[assignment]
+    TPflash = None  # type: ignore[assignment]
+    _HAVE_NEQSIM = False
+
+
+@dataclass
+class _ColumnSpec:
+    """Convenience structure holding the pseudo steady-state design data."""
+
+    overhead_pressure_bar: float = 1.6
+    condenser_duty_tau: float = 0.5
+    reboiler_tau: float = 0.5
+    inventory_tau: float = 0.25
+    feed_temperature_c: float = 95.0
+    feed_pressure_bar: float = 2.2
+
+
+class PlantNeqSim:
+    """First-order benzene/toluene column model using NeqSim for VLE.
+
+    The class exposes the same small API as the historical ``Plant`` stub:
+
+    ``state``
+        Dictionary with the key KPIs tracked by the UI.  Every call to
+        :meth:`step` returns a new dictionary while :meth:`commit` updates
+        the internal copy that becomes the plant state for the next turn.
+
+    ``step(u, scenario)``
+        Evaluate the dynamics with the proposed set-points and scenario
+        disturbances without mutating :attr:`state`.
+
+    ``commit(x_next)``
+        Accept the tentative state coming from :meth:`step`.
+
+    ``esd_safe_state()``
+        Apply an emergency shut-down profile that also acts as a reset for
+        the controllers.
+
+    The model purposefully avoids a full rigorous column solution – each
+    manipulated variable is tracked by a first-order lag to mimic actuator
+    dynamics, and the key quality variables depend on the thermo helper
+    routines.  When the :mod:`neqsim` package is unavailable the code falls
+    back to smooth correlations so that the Streamlit application can still
+    run in documentation / demo environments.
+    """
+
+    def __init__(self) -> None:
+        self.spec = _ColumnSpec()
+        self.state: Dict[str, float] = {
+            "xB_sd": 0.9950,   # benzene purity (side-draw)
+            "dP_col": 0.08,    # bar
+            "T_top": 84.5,     # °C
+            "L_Drum": 0.65,    # 0..1
+            "L_Bot":  0.56,    # 0..1
+            "F_Reflux": 25.0,  # t/h (actual)
+            "F_Reboil": 1.20,  # MW eq. (proxy)
+            "F_ToTol":  55.0,  # t/h
+        }
+        # Cached fluid used to evaluate thermo properties for the current
+        # scenario (makes the physics step cheaper).
+        self._cached_feed: Optional[object] = None
+        self._cached_feed_signature: Optional[tuple] = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _clip(name: str, value: float) -> float:
+        bounds = {
+            "xB_sd": (0.90, 0.9999),
+            "dP_col": (0.02, 0.40),
+            "T_top": (60.0, 110.0),
+            "L_Drum": (0.0, 1.0),
+            "L_Bot": (0.0, 1.0),
+            "F_Reflux": (10.0, 45.0),
+            "F_Reboil": (0.3, 3.5),
+            "F_ToTol": (30.0, 90.0),
+        }
+        lo, hi = bounds[name]
+        return float(np.clip(value, lo, hi))
+
+    def _make_feed_fluid(self, flow_tph: float, zB: float) -> Optional[object]:
+        """Construct or reuse a NeqSim fluid for the given feed conditions."""
+
+        signature = (round(flow_tph, 1), round(zB, 4))
+        if self._cached_feed_signature == signature:
+            return self._cached_feed
+
+        if not _HAVE_NEQSIM:
+            self._cached_feed = {"zB": zB, "flow": flow_tph}
+            self._cached_feed_signature = signature
+            return self._cached_feed
+
+        try:
+            feed = fluid("srk")  # type: ignore[operator]
+            feed.addComponent("benzene", max(zB, 1e-5))
+            feed.addComponent("toluene", max(1.0 - zB, 1e-5))
+            feed.setMixingRule(2)
+            feed.setTemperature(self.spec.feed_temperature_c + 273.15)
+            feed.setPressure(self.spec.feed_pressure_bar)
+            feed.setTotalFlowRate(max(flow_tph, 1e-3), "kg/hr")
+            feed.init(1)
+        except Exception:
+            # Degrade gracefully – behave like the pure dict fallback.
+            feed = {"zB": zB, "flow": flow_tph}
+
+        self._cached_feed = feed
+        self._cached_feed_signature = signature
+        return feed
+
+    def _overhead_T_from_VLE(self, liq_benzene: float, feed_obj: Optional[object]) -> float:
+        """Return an overhead temperature estimate based on VLE."""
+
+        liq_benzene = float(np.clip(liq_benzene, 1e-4, 0.9999))
+
+        if _HAVE_NEQSIM and feed_obj is not None:
+            try:
+                top = fluid("srk")  # type: ignore[operator]
+                top.addComponent("benzene", liq_benzene)
+                top.addComponent("toluene", 1.0 - liq_benzene)
+                top.setMixingRule(2)
+                top.setTemperature(350.0)  # initial guess
+                top.setPressure(self.spec.overhead_pressure_bar)
+                top.init(1)
+                TPflash(top)
+                return float(top.getTemperature() - 273.15)
+            except Exception:
+                pass
+
+        # Fallback: smooth correlation anchored to typical dew points
+        base = 80.1  # benzene boiling point at ~1 atm
+        tol_shift = 21.0  # toluene heavier -> hotter
+        blend = base + tol_shift * (1.0 - liq_benzene) ** 0.85
+        return self._clip("T_top", blend)
+
+    # ------------------------------------------------------------------
+    # Physics integration
+    # ------------------------------------------------------------------
+    def physics_step(self, x: Dict[str, float], u: Dict[str, float], sc: Dict[str, float]) -> Dict[str, float]:
+        """Light-weight dynamic update for the benzene column state."""
+
+        x_next = dict(x)
+
+        feed_flow = float(sc.get("F_feed", 80.0))
+        feed_zB = float(sc.get("zB_feed", 0.60))
+        fouling_cond = float(sc.get("Fouling_Cond", 0.0))
+        fouling_reb = float(sc.get("Fouling_Reb", 0.0))
+
+        feed_fluid = self._make_feed_fluid(feed_flow, feed_zB)
+
+        # Manipulated variable tracking (first-order lag)
+        for key, tau in (
+            ("F_Reflux", self.spec.condenser_duty_tau),
+            ("F_Reboil", self.spec.reboiler_tau),
+            ("F_ToTol", self.spec.inventory_tau),
+        ):
+            sp_key = {
+                "F_Reflux": "SP_F_Reflux",
+                "F_Reboil": "SP_F_Reboil",
+                "F_ToTol": "SP_F_ToTol",
+            }[key]
+            delta = (u[sp_key] - x[key])
+            x_next[key] = self._clip(key, x[key] + (1.0 - np.exp(-1.0 / tau)) * delta)
+
+        # Simple level dynamics – mass balance influenced by feed & draws
+        reflux_dev = x_next["F_Reflux"] - 25.0
+        feed_dev = feed_flow - 80.0
+        toluene_draw_dev = x_next["F_ToTol"] - 55.0
+        reboil_dev = x_next["F_Reboil"] - 1.2
+
+        x_next["L_Drum"] = self._clip(
+            "L_Drum",
+            x["L_Drum"]
+            + 0.0025 * reflux_dev
+            - 0.0015 * toluene_draw_dev
+            + 0.0010 * feed_dev,
+        )
+        x_next["L_Bot"] = self._clip(
+            "L_Bot",
+            x["L_Bot"]
+            + 0.0012 * feed_dev
+            - 0.0016 * toluene_draw_dev
+            - 0.0010 * reboil_dev,
+        )
+
+        # Benzene purity (side draw) responds to separation energy & feed
+        quality_base = x["xB_sd"]
+        purity_gain = (
+            0.0040 * (x_next["F_Reflux"] - 25.0) / 10.0
+            + 0.0030 * (x_next["F_Reboil"] - 1.2)
+            + 0.0025 * (feed_zB - 0.60) / 0.05
+            - 0.0040 * fouling_cond
+            - 0.0030 * fouling_reb
+        )
+        x_next["xB_sd"] = self._clip("xB_sd", quality_base + purity_gain)
+
+        # Column differential pressure increases with vapour traffic & fouling
+        x_next["dP_col"] = self._clip(
+            "dP_col",
+            x["dP_col"]
+            + 0.012 * fouling_cond
+            + 0.010 * feed_dev / 40.0
+            + 0.006 * (x_next["F_Reflux"] - 25.0) / 15.0
+            - 0.004 * (x_next["F_ToTol"] - 55.0) / 15.0,
+        )
+
+        # Overhead temperature from VLE estimate
+        benzene_reflux = np.clip(0.92 + 0.06 * (x_next["xB_sd"] - 0.992) / 0.008 - 0.05 * fouling_cond, 0.85, 0.998)
+        top_temp = self._overhead_T_from_VLE(float(benzene_reflux), feed_fluid)
+        fouling_temp_bias = 12.0 * fouling_cond + 6.0 * fouling_reb
+        x_next["T_top"] = self._clip("T_top", top_temp + fouling_temp_bias)
+
+        return x_next
+
+    # ------------------------------------------------------------------
+    # Public API used by the Streamlit UI
+    # ------------------------------------------------------------------
+    def step(self, u: Dict[str, float], scenario: Dict[str, float]) -> Dict[str, float]:
+        """Compute tentative next state (no commit)."""
+
+        return self.physics_step(self.state, u, scenario)
+
+    def commit(self, x_next: Dict[str, float]) -> None:
+        self.state = dict(x_next)
+
+    def esd_safe_state(self) -> None:
+        """Move the plant towards a conservative safe configuration."""
+
+        safe = {
+            "F_Reflux": 20.0,
+            "F_Reboil": 0.5,
+            "F_ToTol": 45.0,
+        }
+        self.state.update({k: self._clip(k, v) for k, v in safe.items()})
+        self.state["xB_sd"] = max(self.state.get("xB_sd", 0.95) - 0.002, 0.90)
+        self.state["dP_col"] = min(self.state.get("dP_col", 0.20), 0.25)
+        self.state["T_top"] = self._clip("T_top", self.state.get("T_top", 90.0) - 5.0)

--- a/Streamlit/btx-ots/plant_stub.py
+++ b/Streamlit/btx-ots/plant_stub.py
@@ -3,8 +3,15 @@ from typing import Dict
 
 class Plant:
     """
-    Tiny, stable stub of a benzene column "plant".
-    Replace physics_step() with your NN surrogate or DWSIM-backed service.
+    Deprecated light-weight stub of the benzene column model.
+
+    The production Streamlit experience now relies on
+    :class:`plant_neqsim.PlantNeqSim`, which augments the original toy
+    dynamics with NeqSim-based VLE lookups.  This module is kept as a
+    reference implementation and potential fallback for environments where
+    the NeqSim dependency cannot be installed.  The public API intentionally
+    mirrors the NeqSim-backed model so the UI/controllers can switch between
+    implementations without changes.
     """
     def __init__(self):
         self.state = {


### PR DESCRIPTION
## Summary
- add a NeqSim-powered PlantNeqSim model with thermo helpers and first-order dynamics
- update the Streamlit app to instantiate PlantNeqSim by default
- mark the legacy plant stub module as a deprecated fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ce561a008328a38d1eb0fe1b7e4a